### PR TITLE
fix(windows): correct pluginClass to match C API implementation (v2.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 2.2.1
+
+**Patch Release: Fix Windows Build Failure**
+
+### Bug Fixes
+- Fixed `flutter build windows` failure in downstream projects depending on `flutter_image_conversion`
+  - Windows plugin is implemented with the C API pattern (exposes `FlutterImageConversionPluginCApiRegisterWithRegistrar` via `include/flutter_image_conversion/flutter_image_conversion_plugin_c_api.h`), but `pubspec.yaml` declared `pluginClass: FlutterImageConversionPlugin`, causing Flutter's tool to generate `generated_plugin_registrant.cc` that referenced a non-existent header and an undefined register function.
+  - Changed Windows `pluginClass` from `FlutterImageConversionPlugin` to `FlutterImageConversionPluginCApi` so the generated registrant correctly includes `flutter_image_conversion_plugin_c_api.h` and calls `FlutterImageConversionPluginCApiRegisterWithRegistrar`.
+
+### Notes
+- No source code changes; `pubspec.yaml` manifest fix only.
+- Fixes #6.
+
+---
+
 ## 2.2.0
 
 **Feature: WASM Compatibility**

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -121,7 +121,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.2"
+    version: "2.2.1"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/example/windows/flutter/generated_plugin_registrant.cc
+++ b/example/windows/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <flutter_image_conversion/flutter_image_conversion_plugin.h>
+#include <flutter_image_conversion/flutter_image_conversion_plugin_c_api.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
-  FlutterImageConversionPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("FlutterImageConversionPlugin"));
+  FlutterImageConversionPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterImageConversionPluginCApi"));
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   A lightweight Flutter plugin that enables conversion of HEIC images to JPEG format on iOS, macOS, and Web.
   Supports Windows and Android with graceful fallback. Ideal for apps targeting image uploads, social sharing, or cross-platform compatibility.
 
-version: 2.2.0
+version: 2.2.1
 homepage: https://github.com/cyberprophet/flutter-image-conversion
 
 environment:
@@ -34,7 +34,7 @@ flutter:
       macos:
         pluginClass: FlutterImageConversionPlugin
       windows:
-        pluginClass: FlutterImageConversionPlugin
+        pluginClass: FlutterImageConversionPluginCApi
       web:
         pluginClass: FlutterImageConversionWeb
         fileName: flutter_image_conversion_web.dart


### PR DESCRIPTION
## Summary
- Windows 측은 C API 패턴 (`FlutterImageConversionPluginCApiRegisterWithRegistrar` 를 `include/flutter_image_conversion/flutter_image_conversion_plugin_c_api.h` 로 노출) 으로 구현되어 있으나, `pubspec.yaml` 의 `pluginClass` 가 `FlutterImageConversionPlugin` 으로 선언되어 있어 Flutter 툴이 존재하지 않는 헤더/함수를 참조하는 `generated_plugin_registrant.cc` 를 생성, 다운스트림 `flutter build windows` 실패.
- `pluginClass` 를 `FlutterImageConversionPluginCApi` 로 교체 — 소스 코드 변경 없이 pubspec 한 줄 수정으로 해결.
- 버전 2.2.0 → 2.2.1, CHANGELOG 업데이트.

## Test plan
- [x] `flutter pub publish --dry-run` 통과 (uncommitted-files 경고 외 이슈 없음)
- [x] `example/` 에서 `flutter pub get` 재실행 후 `example/windows/flutter/generated_plugin_registrant.cc` 가 `flutter_image_conversion_plugin_c_api.h` 를 include 하고 `FlutterImageConversionPluginCApiRegisterWithRegistrar` 를 호출하는지 확인
- [ ] merge 후 태그 `v2.2.1` 푸시 → `publish_pubdev.yml` 워크플로우가 pub.dev 에 배포하는지 확인

Fixes #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)